### PR TITLE
feat(server): continue capturing while cropping and saving

### DIFF
--- a/client/components/Notifications.jsx
+++ b/client/components/Notifications.jsx
@@ -12,11 +12,17 @@ function Notifications() {
   // projector
   useCommsNotificationValue(
     'captureStats',
-    ({ stats: { frameCount, started, now } }) => {
+    ({
+      stats: {
+        capturedFrameCount, savedFrameCount, started, now,
+      },
+    }) => {
       const secondsElapsed = Math.round((now - started) / 1e3);
       // allNotifications reference here is only the first value
-      // TODO: refactor this clumbsy approach (in every usage)
-      allNotifications.captureStats = `${frameCount} frames in ${secondsElapsed}s, or ${friendlyRound(frameCount / secondsElapsed)} fps (${friendlyRound(secondsElapsed / frameCount)} spf)`;
+      // TODO: refactor this clumsy approach (in every usage)
+      allNotifications.captureStats = ''
+        + `captured ${capturedFrameCount} frames in ${secondsElapsed}s, or ${friendlyRound(capturedFrameCount / secondsElapsed)} fps (${friendlyRound(secondsElapsed / capturedFrameCount)} spf)\n`
+        + `saved ${savedFrameCount} frames in ${secondsElapsed}s, or ${friendlyRound(savedFrameCount / secondsElapsed)} fps (${friendlyRound(secondsElapsed / savedFrameCount)} spf)`;
       setNotifications({ ...allNotifications });
     },
     null

--- a/server/camera.js
+++ b/server/camera.js
@@ -129,7 +129,7 @@ function takePhoto() {
           height,
         },
       };
-      setTimeout(() => cameraEvents.emit('frame', latestFrame), 1007);
+      setTimeout(() => cameraEvents.emit('frame', latestFrame), 100);
       return latestFrame;
     });
 
@@ -142,17 +142,19 @@ function captureFrame() {
     .then(({ photo, encoding }) => {
       console.timeEnd('captureFrame call of takePhoto');
       console.time('extract & toBuffer');
-      return sharp(photo)
-        .extract(cropWindow)
-        .toBuffer()
-        .then((croppedPhoto) => {
-          console.timeEnd('extract & toBuffer');
-          return {
-            photo: croppedPhoto,
-            encoding,
-            size: cropWindow,
-          };
-        });
+      return {
+        cropPromise: sharp(photo)
+          .extract(cropWindow)
+          .toBuffer()
+          .then((croppedPhoto) => {
+            console.timeEnd('extract & toBuffer');
+            return {
+              photo: croppedPhoto,
+              encoding,
+              size: cropWindow,
+            };
+          }),
+      };
     });
 }
 


### PR DESCRIPTION
This got my time per frame down to one second, sometimes the average was even less. The danger is if cropping takes longer than the frame acquisition memory usage will build and the process will crash. As the two operations were very close in time taken (each about 700ms if memory serves correctly) this was not an issue "on my machine" and RasPi's are generally pretty consistent. A guard would need to be put in place if this was to be product-ified.